### PR TITLE
Alexharvey/setup unit tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    wait_for: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 pkg
 .idea
 .project
+Gemfile.lock
+spec/fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+language: ruby
+bundler_args: --without system_tests
+before_install: rm Gemfile.lock || true
+matrix:
+  include:
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0"
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,20 @@
+source 'https://rubygems.org'
+
+group :development do
+  gem 'pry'
+  gem 'pry-rescue'
+  gem 'pry-stack_explorer'
+end
+
+group :tests do
+  gem 'rspec-mocks'
+  gem 'puppetlabs_spec_helper'
+end
+
+gem 'facter'
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion
+else
+  gem 'puppet'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -62,7 +62,9 @@ Puppet::Type.newtype(:wait_for) do
     unless self[:regex] or self[:exit_code] or self[:seconds]
       fail "Exactly one of regex, seconds or exit_code is required."
     end
-    if self[:regex] and self[:exit_code] or self[:regex] and self[:seconds] or self[:exit_code] and self[:seconds]
+    if (self[:regex] and not self[:exit_code].nil?) or
+       (self[:regex] and not self[:seconds].nil?) or
+       (not self[:exit_code].nil? and not self[:seconds].nil?)
       fail "Attributes regex, seconds and exit_code are mutually exclusive."
     end
   end

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -46,13 +46,13 @@ Puppet::Type.newtype(:wait_for) do
   newparam(:environment, :array_matching => :all) do
     desc "An array of strings of the form 'key=value', which will be injected into the environment of the query command."
     defaultto []
-    munge do |value|
-      Array(value)
-    end
     validate do |value|
+      unless value.is_a?(Array)
+        raise ArgumentError, "#{value} is not an array"
+      end
       value.each do |item|
         unless item =~ /^\w+=.*/
-          raise ArgumentError, "%s is not a key=value pair" % item
+          raise ArgumentError, "#{item} is not a key=value pair"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec/mocks'
+
+RSpec.configure do |c|
+  c.formatter = :documentation
+  c.tty       = true
+  c.mock_with :rspec
+end

--- a/spec/unit/puppet/provider/wait_for_spec.rb
+++ b/spec/unit/puppet/provider/wait_for_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:wait_for).provider(:wait_for) do
+
+  context 'query with regex that never matches' do
+    let(:resource) do
+      Puppet::Type.type(:wait_for).new(
+        :query => 'echo foo bar',
+        :regex => 'baz',
+      )
+    end
+    let(:provider) { resource.provider }
+
+    it 'should time out after 119 retries' do
+      expect { provider.send(:regex) }.to_not raise_error
+      expect_any_instance_of(Object).to receive(:sleep).with(0.5).exactly(119).times
+      expect { provider.send('regex=', /baz/) }.to raise_error(
+        Puppet::Error, %r{wait_for timed out})
+    end
+  end
+
+  context 'query with regex that immediately matches' do
+    let(:resource) do
+      Puppet::Type.type(:wait_for).new(
+        :query => 'echo foo bar',
+        :regex => 'foo',
+      )
+    end
+    let(:provider) { resource.provider }
+
+    it 'should immediately succeed if regex matches' do
+      expect(provider.send(:regex)).to be_truthy
+    end
+  end
+
+  context 'query with regex with custom polling_interval and max_retries' do
+    let(:resource) do
+      Puppet::Type.type(:wait_for).new(
+        :query             => 'echo foo bar',
+        :regex             => 'baz',
+        :polling_frequency => 1,
+        :max_retries       => 10,
+      )
+    end
+    let(:provider) { resource.provider }
+
+    it 'should time out after 10 retries' do
+      expect { provider.send(:regex) }.to_not raise_error
+      expect_any_instance_of(Object).to receive(:sleep).with(1).exactly(10).times
+      expect { provider.send('regex=', /baz/) }.to raise_error(
+        Puppet::Error, %r{wait_for timed out})
+    end
+  end
+
+  context 'sleep for a number of seconds' do
+    let(:resource) do
+      Puppet::Type.type(:wait_for).new(
+        :name    => 'a_minute',
+        :seconds => 60,
+      )
+    end
+    let(:provider) { resource.provider }
+
+    it 'should sleep for 60 seconds' do
+      expect_any_instance_of(Object).to receive(:sleep).with(60).once
+      provider.send(:seconds)
+    end
+  end
+
+  context 'wait for an exit code' do
+    # TODO. Not easy to test due to use of $? which, as far as I can tell, cannot be stubbed,
+    # e.g. https://stackoverflow.com/questions/4589460/is-there-a-way-to-set-the-value-of-in-a-mock-in-ruby
+  end
+end

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:wait_for) do
+  let(:wait_for) do
+    Puppet::Type.type(:wait_for).new(:query => 'echo foo bar', :regex => 'foo')
+  end
+
+  test_data = {
+
+    # Illustrating some consequences of acceptable input values due
+    # to the type's data type coercion.
+    #
+    :exit_code   => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
+    :seconds     => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
+    :max_retries => [[42.5, 42], [42, 42], ['42', 42]],
+    :polling_frequency => [[1.5, 1.5], [1, 1.0]],
+    :regex             => [[/foo/, /foo/], ['foo', /foo/]],
+  }
+
+  test_data.each do |k,v|
+    v.each do |val|
+      i, o = val
+      it "accepts #{k}=>#{i}" do
+        wait_for[k] = i
+        expect(wait_for[k]).to eq o
+      end
+    end
+  end
+
+  it 'does not raise error' do
+    expect { wait_for }.not_to raise_error
+  end
+
+  bad_opts = [
+    # {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42}, FIXME. This is failing but it should pass.
+    {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42, :seconds => 42},
+    {:query  => 'echo foo bar', :regex  => 'foo', :seconds => 42},
+    {:query  => 'echo foo bar', :exit_code => 42, :seconds => 42},
+  ]
+
+  bad_opts.each do |params|
+    it "errors out with illegal opts #{params}" do
+      expect { Puppet::Type.type(:wait_for).new(params) }.to raise_error(
+        Puppet::Error, %r{Attributes regex, seconds and exit_code are mutually exclusive}
+      )
+    end
+  end
+
+  it 'errors out unless one of regex, seconds or exit_code is specified' do
+    expect {
+      Puppet::Type.type(:wait_for).new(
+        :query  => 'echo foo bar',
+      )
+    }.to raise_error(
+      Puppet::ResourceError, %r{Exactly one of regex, seconds or exit_code is required}
+    )
+  end
+
+  it 'errors out if environment is not an array of strings like key=value' do
+    expect {
+      Puppet::Type.type(:wait_for).new(
+        :query  => 'echo foo bar',
+        :environment => ['foo'],
+      )
+    }.to raise_error(
+      Puppet::ResourceError, %r{foo is not a key=value pair}
+    )
+  end
+
+  defaults = {
+    :polling_frequency => 0.5,
+    :max_retries => 119,
+    :environment => [],
+  }
+
+  defaults.each do |k,v|
+    it "defaults #{k} => #{v}" do
+      expect(wait_for[k]).to eq v
+    end
+  end
+end

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:wait_for) do
   end
 
   bad_opts = [
-    # {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42}, FIXME. This is failing but it should pass.
+    {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42},
     {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42, :seconds => 42},
     {:query  => 'echo foo bar', :regex  => 'foo', :seconds => 42},
     {:query  => 'echo foo bar', :exit_code => 42, :seconds => 42},

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -56,6 +56,17 @@ describe Puppet::Type.type(:wait_for) do
     )
   end
 
+  it 'errors out if environment is not an array' do
+    expect {
+      Puppet::Type.type(:wait_for).new(
+        :query  => 'echo foo bar',
+        :environment => 'foo',
+      )
+    }.to raise_error(
+      Puppet::ResourceError, %r{foo is not an array}
+    )
+  end
+
   it 'errors out if environment is not an array of strings like key=value' do
     expect {
       Puppet::Type.type(:wait_for).new(


### PR DESCRIPTION
- Correction to validation of inputs
    
    The code was not actually testing for mutually exclusive inputs, so I
    tweaked the logic so that it did.

- Correction to validation of environment
    
    The logic for validating the environment was incorrect ; values are
    always validated before they’re munged, see:
    https://puppet.com/docs/puppet/5.5/custom_types.html
    
    Thus it is not possible to coerce a string input value to an Array, and
    so I changed the code to simply fail if a string value is passed.

- Add unit tests and set up Travis CI
    
    Adds Rspec tests for the type and provider. Note that some of these
    tests are failing due to bugs in the validation uncovered during the
    testing.
    
    Also adds a .travis.yml to run the tests against Ruby 2.1 / Puppet 3,
    Ruby 2.4 / Pupppet 4/5.
