### PR TITLE
Refreshonly feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ bundler_args: --without system_tests
 before_install: rm Gemfile.lock || true
 matrix:
   include:
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+#  - rvm: 2.1.0
+#    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.0
     env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ bundler_args: --without system_tests
 before_install: rm Gemfile.lock || true
 matrix:
   include:
-#  - rvm: 2.1.0
-#    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.0
     env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.4.1

--- a/lib/puppet/provider/wait_for/wait_for_provider.rb
+++ b/lib/puppet/provider/wait_for/wait_for_provider.rb
@@ -32,13 +32,10 @@ Puppet::Type.type(:wait_for).provide(:wait_for) do
       #
       # This is backwards compatible all the way to Ruby 1.8.7.
       Timeout::timeout(resource[:timeout], Timeout::Error) do
-        # note that we are passing "false" for the "override_locale" parameter, which ensures that the user's
-        # default/system locale will be respected.  Callers may override this behavior by setting locale-related
-        # environment variables (LANG, LC_ALL, etc.) in their 'environment' configuration.
         output = Puppet::Util::Execution.execute(['/bin/sh', '-c', command],
                                 :failonfail => false,
                                 :combine => true,
-                                :override_locale => false,
+                                :override_locale => true,
                                 :custom_environment => environment)
       end
       # The shell returns 127 if the command is missing.

--- a/lib/puppet/provider/wait_for/wait_for_provider.rb
+++ b/lib/puppet/provider/wait_for/wait_for_provider.rb
@@ -1,5 +1,7 @@
 require 'puppet/util/execution'
 
+# Most of this code is copied from the Exec provider.
+#
 Puppet::Type.type(:wait_for).provide(:wait_for) do
   include Puppet::Util::Execution
 
@@ -48,9 +50,13 @@ Puppet::Type.type(:wait_for).provide(:wait_for) do
       self.fail Puppet::Error, detail.to_s, detail
     end
 
-    # Return output twice as processstatus was returned before, but only exitstatus was ever called.
-    # Output has the exitstatus on it so it is returned instead. This is here twice as changing this
-    #  would result in a change to the underlying API.
-    return output, output
+    return output
+  end
+
+  def seconds
+    seconds = resource[:seconds]
+    info "Waiting for #{seconds} seconds..."
+    sleep seconds
+    return seconds
   end
 end

--- a/lib/puppet/provider/wait_for/wait_for_provider.rb
+++ b/lib/puppet/provider/wait_for/wait_for_provider.rb
@@ -2,35 +2,35 @@ Puppet::Type.type(:wait_for).provide(:wait_for) do
   desc "Waits for something to happen."
 
   def exit_code
-    query = resource[:query]
+    fetch_parameters
     set_environment
-    `#{query}`
+    `#{@query}`
     return $?
   end
 
-  def exit_code=(expected_exit_code)
-    fetch_parameters
-    info "waiting until the exit code of #{@query} is #{expected_exit_code.to_s}"
+  def exit_code=(expected)
+    info "waiting until the exit code of #{@query} is #{expected}"
     info "polling frequency #{@polling_frequency}, max retries #{@max_retries}"
-    error_message = "wait_for timed out while waiting until the exit code of #{@query} became #{expected_exit_code}, after #{@max_retries} retries with polling frequency #{@polling_frequency}."
-    query_and_wait(error_message) do |exit_code, output|
-      if expected_exit_code == exit_code
+
+    message = set_message("the exit code of #{@query} became #{expected}")
+
+    query_and_wait(message) do |exit_code, output|
+      if expected == exit_code
         info "Detected expected exit code."
-        return expected_exit_code
+        return expected
       else
-        debug "Exit code is #{exit_code} but we are waiting for #{expected_exit_code}."
+        debug "Exit code is #{exit_code} but we are waiting for #{expected}."
       end
     end
   end
 
   def regex
-    query = resource[:query]
-    regex = resource[:regex]
+    fetch_parameters
     set_environment
-    output = `#{query}`
-    if output =~ regex
+    output = `#{@query}`
+    if output =~ @regex
       info "Query output matched regex."
-      return regex
+      return @regex
     else
       return nil
     end
@@ -38,57 +38,69 @@ Puppet::Type.type(:wait_for).provide(:wait_for) do
 
   def regex=(regex)
     fetch_parameters
-    info "waiting until the output of #{@query} matches #{regex.to_s}"
+
+    info "waiting until the output of #{@query} matches #{regex}"
     info "polling frequency #{@polling_frequency}, max retries #{@max_retries}"
-    error_message = "wait_for timed out while waiting until the output of #{@query} matched #{regex}, after #{@max_retries} retries with polling frequency #{@polling_frequency}."
-    query_and_wait(error_message) do |exit_code, output|
+
+    message = set_message("the output of #{@query} matched #{regex}")
+
+    query_and_wait(message) do |exit_code, output|
       if output =~ regex
         info "Query output matched regex."
         return regex
       else
-        debug "Query output #{output} did not match regex #{regex.to_s}."
+        debug "Query output #{output} did not match regex #{regex}."
       end
     end
   end
 
   def seconds
-    seconds = resource[:seconds]
-    info "Waiting for #{seconds} seconds..."
-    sleep(seconds)
-    return seconds
+    fetch_parameters
+    info "Waiting for #{@seconds} seconds..."
+    sleep(@seconds)
+    return @seconds
   end
 
-  private
+ private
 
   def fetch_parameters
-    @query             = resource[:query]
+    @query    = resource[:query]
+    @regex    = resource[:regex]
+    @seconds  = resource[:seconds]
+    @environment = resource[:environment]
+    @max_retries = resource[:max_retries]
     @polling_frequency = resource[:polling_frequency]
-    @max_retries       = resource[:max_retries]
   end
 
   def set_environment
-    environment = resource[:environment]
-    environment.each do |item|
-      (key, value) = item.split('=')
+    @environment.each do |item|
+      key, value = item.split('=')
       debug "Setting environment variable #{key}."
       ENV[key] = value
     end
   end
 
-  def query_and_wait(error_message)
-    set_environment
-    for i in 1..@max_retries
-      debug "Retry #{i}"
+  def set_message(reason)
+    return "wait_for timed out while waiting until #{reason}, " \
+      "after #{@max_retries} retries " \
+      "with polling frequency #{@polling_frequency}."
+  end
+
+  def query_and_wait(message)
+    1.upto(@max_retries) do |i|
+
       output    = `#{@query}`
       exit_code = $?
-      debug "exit code: #{exit_code.to_s}"
-      debug "output: #{output.to_s}"
+
+      debug "Retry #{i}"
+      debug "exit code: #{exit_code}"
+      debug "output: #{output}"
 
       yield(exit_code, output)
 
       sleep @polling_frequency
     end
 
-    fail error_message
+    fail message
   end
 end

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -1,136 +1,190 @@
-# A type to wait for a command to return an expected output
-Puppet::Type.newtype(:wait_for) do
-  @doc = "Waits for something to happen."
+module Puppet
+  Type.newtype(:wait_for) do
+    include Puppet::Util::Execution
+    require 'timeout'
 
-  ## Begin copy/paste from exec.
+    @doc = "TODO"
 
-  # Create a new check mechanism.  It's basically just a parameter that
-  # provides one extra 'check' method.
-  def self.newcheck(name, options = {}, &block)
-    @checks ||= {}
+    # Create a new check mechanism.  It's basically just a parameter that
+    # provides one extra 'check' method.
+    def self.newcheck(name, options = {}, &block)
+      @checks ||= {}
 
-    check = newparam(name, options, &block)
-    @checks[name] = check
-  end
+      check = newparam(name, options, &block)
+      @checks[name] = check
+    end
 
-  def self.checks
-    @checks.keys
-  end
+    def self.checks
+      @checks.keys
+    end
 
-  # Verify that we pass all of the checks.  The argument determines whether
-  # we skip the :refreshonly check, which is necessary because we now check
-  # within refresh
-  def check_all_attributes(refreshing=false)
-    self.class.checks.each { |check|  # I think "checks" are newchecks, here only one.
-      next if refreshing and check == :refreshonly
+    newproperty(:exit_code, :array_matching => :all) do |property|
+      desc "TODO"
 
-      if @parameters.include?(check) # @parameters comes from Puppet::Type
-        val = @parameters[check].value
-        val = [val] unless val.is_a? Array
-        val.each do |value|
-          return false unless @parameters[check].check(value)
+      include Puppet::Util::Execution
+
+      attr_reader :output
+
+      munge do |value|
+        value.to_s
+      end
+
+      defaultto 0
+
+      # First verify that all of our checks pass.
+      def retrieve
+        # We need to return :notrun to trigger evaluation; when that isn't
+        # true, we *LIE* about what happened and return a "success" for the
+        # value, which causes us to be treated as in_sync?, which means we
+        # don't actually execute anything.  I think. --daniel 2011-03-10
+        if @resource.check_all_attributes
+          return :notrun
+        else
+          return self.should
         end
       end
-    }
 
-    true
-  end
+      # Actually wait for the exit code.
+      def sync
+        tries = self.resource[:max_retries]
+        try_sleep = self.resource[:polling_frequency]
 
-  # Run the command, or optionally run a separately-specified command.
-  def refresh
-    self.check_all_attributes(true)
-
-      # FIXME. Delete. Copied from Exec. Not needed here.
-      #
-      # if cmd = self[:refresh]
-      #   provider.run(cmd)
-      # else
-      #   self.property(:returns).sync
-      # end
+        begin
+          tries.times do |try|
+            # Only add debug messages for tries > 1 to reduce log spam.
+            debug("Exec try #{try+1}/#{tries}") if tries > 1
+            @output, @status = provider.run(self.resource[:query])
+            break if self.should.include?(@status.exitstatus.to_s)
+            if try_sleep > 0 and tries > 1
+              debug("Sleeping for #{try_sleep} seconds between tries")
+              sleep try_sleep
+            end
+          end
+        rescue Timeout::Error
+          self.fail Puppet::Error, _("Query exceeded timeout"), $!
+        end
+      end
     end
-  end
 
-  newcheck(:refreshonly) do
-    newvalues(:true, :false)
+    newparam(:query) do
+      isnamevar
+      desc ""
 
-    # We always fail this test, because we're only supposed to run
-    # on refresh.
-    def check(value)
-      # We have to invert the values.
-      if value == :true
-        false
+      validate do |command|
+        raise ArgumentError, _("Command must be a String, got value of class %{klass}") % { klass: command.class } unless command.is_a? String
+      end
+    end
+
+    newparam(:environment) do
+      desc ""
+
+      validate do |values|
+        values = [values] unless values.is_a? Array
+        values.each do |value|
+          unless value =~ /\w+=/
+            raise ArgumentError, _("Invalid environment setting '%{value}'") % { value: value }
+          end
+        end
+      end
+    end
+
+    newparam(:timeout) do
+      desc ""
+
+      munge do |value|
+        value = value.shift if value.is_a?(Array)
+        begin
+          value = Float(value)
+        rescue ArgumentError
+          raise ArgumentError, _("The timeout must be a number."), $!.backtrace
+        end
+        [value, 0.0].max
+      end
+
+      defaultto 300
+    end
+
+    newparam(:max_retries) do
+      desc "The number of times execution of the command should be tried.
+        Defaults to '1'. This many attempts will be made to execute
+        the command until an acceptable return code is returned.
+        Note that the timeout parameter applies to each try rather than
+        to the complete set of tries."
+
+      munge do |value|
+        if value.is_a?(String)
+          unless value =~ /^[\d]+$/
+            raise ArgumentError, _("Tries must be an integer")
+          end
+          value = Integer(value)
+        end
+        raise ArgumentError, _("Tries must be an integer >= 1") if value < 1
+        value
+      end
+
+      defaultto 1
+    end
+
+    newparam(:polling_frequency) do
+      desc "The time to sleep in seconds between 'tries'."
+
+      munge do |value|
+        value = Integer(value)
+        raise ArgumentError, _("polling_frequency cannot be a negative number") if value < 0
+        value
+      end
+
+      defaultto 0
+    end
+
+    newcheck(:refreshonly) do
+      desc <<-'EOT'
+      EOT
+
+      newvalues(:true, :false)
+
+      # We always fail this test, because we're only supposed to run
+      # on refresh.
+      def check(value)
+        # We have to invert the values.
+        if value == :true
+          false
+        else
+          true
+        end
+      end
+    end
+
+    # Verify that we pass all of the checks.  The argument determines whether
+    # we skip the :refreshonly check, which is necessary because we now check
+    # within refresh
+    def check_all_attributes(refreshing = false)
+      self.class.checks.each { |check|
+        next if refreshing and check == :refreshonly
+        if @parameters.include?(check)
+          val = @parameters[check].value
+          val = [val] unless val.is_a? Array
+          val.each do |value|
+            return false unless @parameters[check].check(value)
+          end
+        end
+      }
+
+      true
+    end
+
+    def output
+      if self.property(:exit_code).nil?
+        return nil
       else
-        true
+        return self.property(:exit_code).output
       end
     end
-  end
 
-  ## End copy/paste from exec.
-
-  newparam(:query, :namevar => true) do
-    desc "The command to execute, the output of this command will be matched against regex."
-  end
-
-  newproperty(:exit_code) do
-    desc "The exit code to expect."
-    munge do |value|
-      Integer(value)
-    end
-  end
-
-  newproperty(:regex) do
-    desc "The regex to match the commmand's output against."
-    munge do |value|
-      Regexp.new(value)
-    end
-  end
-
-  newproperty(:seconds) do
-    desc "How long to just wait."
-    munge do |value|
-      Integer(value)
-    end
-  end
-
-  newparam(:polling_frequency) do
-    desc "How long to sleep in between retries."
-    defaultto 0.5
-    munge do |value|
-      Float(value)
-    end
-  end
-
-  newparam(:max_retries) do
-    desc "How often to retry the query before timing out."
-    defaultto 119
-    munge do |value|
-      Integer(value)
-    end
-  end
-
-  newparam(:environment, :array_matching => :all) do
-    desc "An array of strings of the form 'key=value', which will be injected into the environment of the query command."
-    defaultto []
-    validate do |value|
-      unless value.is_a?(Array)
-        raise ArgumentError, "#{value} is not an array"
+    def refresh
+      if self.check_all_attributes(true)
+        self.property(:exit_code).sync
       end
-      value.each do |item|
-        unless item =~ /^\w+=.*/
-          raise ArgumentError, "#{item} is not a key=value pair"
-        end
-      end
-    end
-  end
-
-  validate do
-    unless self[:regex] or self[:exit_code] or self[:seconds]
-      fail "Exactly one of regex, seconds or exit_code is required."
-    end
-    if (self[:regex] and not self[:exit_code].nil?) or
-       (self[:regex] and not self[:seconds].nil?) or
-       (not self[:exit_code].nil? and not self[:seconds].nil?)
-      fail "Attributes regex, seconds and exit_code are mutually exclusive."
     end
   end
 end

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:wait_for) do
           end
         end
       rescue Timeout::Error
-        self.fail Puppet::Error, _("Query exceeded timeout"), $!
+        self.fail Puppet::Error, "Query exceeded timeout", $!
       end
     end
   end
@@ -100,7 +100,7 @@ Puppet::Type.newtype(:wait_for) do
           end
         end
       rescue Timeout::Error
-        self.fail Puppet::Error, _("Query exceeded timeout"), $!
+        self.fail Puppet::Error, "Query exceeded timeout", $!
       end
     end
   end
@@ -120,7 +120,7 @@ Puppet::Type.newtype(:wait_for) do
 
     validate do |command|
       raise ArgumentError,
-        _("Command must be a String, got value of class %{klass}") % { klass: command.class } unless command.is_a?(String)
+        "Command must be a String, got value of class #{command.class}" unless command.is_a?(String)
     end
   end
 
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:wait_for) do
       values = [values] unless values.is_a?(Array)
       values.each do |value|
         unless value =~ /\w+=/
-          raise ArgumentError, _("Invalid environment setting '%{value}'") % { value: value }
+          raise ArgumentError, "Invalid environment setting '#{value}'"
         end
       end
     end
@@ -156,9 +156,9 @@ Puppet::Type.newtype(:wait_for) do
       begin
         value = value.to_f
       rescue ArgumentError
-        raise ArgumentError, _("The timeout must be a number."), $!.backtrace
+        raise ArgumentError, "The timeout must be a number.", $!.backtrace
       end
-      raise ArgumentError, _("The timeout cannot be a negative number") if value < 0
+      raise ArgumentError, "The timeout cannot be a negative number" if value < 0
     end
 
     defaultto 300
@@ -176,11 +176,11 @@ Puppet::Type.newtype(:wait_for) do
     munge do |value|
       if value.is_a?(String)
         unless value =~ /^[\d]+$/
-          raise ArgumentError, _("Tries must be an integer")
+          raise ArgumentError, "Tries must be an integer"
         end
         value = Integer(value)
       end
-      raise ArgumentError, _("Tries must be an integer >= 1") if value < 1
+      raise ArgumentError, "Tries must be an integer >= 1" if value < 1
       value
     end
 
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:wait_for) do
 
     munge do |value|
       value = Float(value)
-      raise ArgumentError, _("polling_frequency cannot be a negative number") if value < 0
+      raise ArgumentError, "polling_frequency cannot be a negative number" if value < 0
       value
     end
 

--- a/spec/unit/puppet/provider/wait_for_spec.rb
+++ b/spec/unit/puppet/provider/wait_for_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:wait_for).provider(:wait_for) do
 
-  context 'query with regex that never matches' do
+  context '#run' do
     let(:resource) do
       Puppet::Type.type(:wait_for).new(
         :query => 'echo foo bar',
@@ -11,48 +11,13 @@ describe Puppet::Type.type(:wait_for).provider(:wait_for) do
     end
     let(:provider) { resource.provider }
 
-    it 'should time out after 119 retries' do
-      expect { provider.send(:regex) }.to_not raise_error
-      expect_any_instance_of(Object).to receive(:sleep).with(0.5).exactly(119).times
-      expect { provider.send('regex=', /baz/) }.to raise_error(
-        Puppet::Error, %r{wait_for timed out})
+    it 'should run a command' do
+      output = provider.run('echo foo bar')
+      expect(output).to eq "foo bar\n"
     end
   end
 
-  context 'query with regex that immediately matches' do
-    let(:resource) do
-      Puppet::Type.type(:wait_for).new(
-        :query => 'echo foo bar',
-        :regex => 'foo',
-      )
-    end
-    let(:provider) { resource.provider }
-
-    it 'should immediately succeed if regex matches' do
-      expect(provider.send(:regex)).to be_truthy
-    end
-  end
-
-  context 'query with regex with custom polling_interval and max_retries' do
-    let(:resource) do
-      Puppet::Type.type(:wait_for).new(
-        :query             => 'echo foo bar',
-        :regex             => 'baz',
-        :polling_frequency => 1,
-        :max_retries       => 10,
-      )
-    end
-    let(:provider) { resource.provider }
-
-    it 'should time out after 10 retries' do
-      expect { provider.send(:regex) }.to_not raise_error
-      expect_any_instance_of(Object).to receive(:sleep).with(1).exactly(10).times
-      expect { provider.send('regex=', /baz/) }.to raise_error(
-        Puppet::Error, %r{wait_for timed out})
-    end
-  end
-
-  context 'sleep for a number of seconds' do
+  context '#seconds' do
     let(:resource) do
       Puppet::Type.type(:wait_for).new(
         :name    => 'a_minute',
@@ -65,10 +30,5 @@ describe Puppet::Type.type(:wait_for).provider(:wait_for) do
       expect_any_instance_of(Object).to receive(:sleep).with(60).once
       provider.send(:seconds)
     end
-  end
-
-  context 'wait for an exit code' do
-    # TODO. Not easy to test due to use of $? which, as far as I can tell, cannot be stubbed,
-    # e.g. https://stackoverflow.com/questions/4589460/is-there-a-way-to-set-the-value-of-in-a-mock-in-ruby
   end
 end

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -10,9 +10,9 @@ describe Puppet::Type.type(:wait_for) do
     # Illustrating some consequences of acceptable input values due
     # to the type's data type coercion.
     #
-    :exit_code   => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
+    :exit_code   => [[42.5, [42]], [[42], [42]], [42, [42]], ['42', [42]], [[1,'2','42'], [1,2,42]]],
     :seconds     => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
-    :max_retries => [[42.5, 42], [42, 42], ['42', 42]],
+    :max_retries => [[42.5, 42.5], [42, 42], ['42', 42]],
     :polling_frequency => [[1.5, 1.5], [1, 1.0]],
     :regex             => [[/foo/, /foo/], ['foo', /foo/]],
   }
@@ -63,7 +63,7 @@ describe Puppet::Type.type(:wait_for) do
         :environment => 'foo',
       )
     }.to raise_error(
-      Puppet::ResourceError, %r{foo is not an array}
+      Puppet::ResourceError, %r{Invalid environment setting 'foo'}
     )
   end
 
@@ -74,14 +74,13 @@ describe Puppet::Type.type(:wait_for) do
         :environment => ['foo'],
       )
     }.to raise_error(
-      Puppet::ResourceError, %r{foo is not a key=value pair}
+      Puppet::ResourceError, %r{Invalid environment setting 'foo'}
     )
   end
 
   defaults = {
     :polling_frequency => 0.5,
     :max_retries => 119,
-    :environment => [],
   }
 
   defaults.each do |k,v|

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -52,3 +52,59 @@ include wait_for
 #   query   => 'echo foobar',
 #   regex   => 'foobar',
 # }
+
+# Tests added for the refreshonly feature.
+
+# file { '/tmp/exit_code.sh':
+#   ensure  => file,
+#   mode    => '0755',
+#   content => "#!/bin/bash
+# sleep 5
+# exit 42
+# ",
+# }
+
+# file { '/tmp/gen_log.sh':
+#   ensure => file,
+#   mode   => '0755',
+#   content => "#!/bin/bash
+# sleep 20
+# echo bar >> /tmp/logfile
+# ",
+# }
+
+# notify { 'expecting to see Wait_for A, C and E': }
+
+# notify { 'A': }
+# ~>
+# wait_for { 'A':
+#   seconds     => 1,
+#   refreshonly => true,
+# }
+
+# wait_for { 'B_should_not_run':
+#   seconds     => 5,
+#   refreshonly => true,
+# }
+
+# notify { 'C': }
+# ~>
+# wait_for { 'C':
+#   query       => '/tmp/exit_code.sh',
+#   exit_code   => 42,
+#   refreshonly => true,
+# }
+
+# wait_for { 'D_should_not_run':
+#   query       => 'echo hello',
+#   regex       => 'world',
+#   refreshonly => true,
+# }
+
+# exec { '/tmp/gen_log.sh': }
+# ~>
+# wait_for { 'E':
+#   query       => 'cat /tmp/logfile',
+#   regex       => 'bar',
+#   refreshonly => true,
+# }


### PR DESCRIPTION
- Add the tests
    
    Add the (manual) tests I did into tests/init.pp.

- Refactor to remove duplication
    
    I add a module of helper methods, which are mixed into the Exit_code and
    Regex classes (properties) to deal with the duplication of the retrieve
    and sync methods.

- Corrections for Puppet 3
    
    When I copied the Exec type, I used the latest from Puppet's master
    branch, and this broke Puppet 3.

- Comment out puppet 3 tests in .travis.yml
    
    This temporarily removes testing for Puppet 3. Something is broken
    upstream. I notified Puppet of the issue.

- Add remaining features and tests and refactor
    
    Add the remaining features for a complete rewrite. Fix up tests as
    appropriate.
    
    Notes about changed behaviour:
    
    - The exit_code parameter now allows for an array of exit_codes, similar
    to Exec.
    
    - Validation for String added on the :query parameter.
    
    - The implementation of environment is now copy/pasted from Exec.
    
    - Debug logging is changed based on the reimplementation by copy/pasting
    from Exec. i.e. I did not try to preserve the logging messages.
    
    - Likewise, the error messages changed in a few places.

- Add proof of concept rewrite
    
    Using the built-in Exec type as a starting point, and renaming
    parameters
    
    (The renamed parameters are:
      :command   => :query
      :retries   => :max_retries
      :try_sleep => :polling_frequency)
    
    Then the Exec :returns property becomes the Wait_for :exit_code, which
    then becomes a property instead of a command.
    
    Polling_frequency is changed to accept Floats (and looking at the code,
    it would be trivial to fix the Exec type so that it too accepted
    Floats!)
    
    I get the refreshonly functionality working.
    
    To test, create these two files:
    
      # /tmp/exit_code.sh
      #!/bin/bash
      sleep 5
      exit 42
    
    and
    
      # /tmp/test.pp
      notify { 'foo': }
      ~>
      wait_for { '/tmp/exit_code.sh':
        exit_code   => 42,
        refreshonly => true,
      }
    
    Then:
    
      $ bundle exec puppet apply --modulepath=spec/fixtures/modules \
         /tmp/test.pp
