### PR TITLE
Change regex to type to a string

### DIFF
--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -43,7 +43,7 @@ module Mixins
           if self.class == Puppet::Type::Wait_for::Exit_code
             break if self.should.include?(@output.exitstatus.to_i)
           elsif self.class == Puppet::Type::Wait_for::Regex
-            break if @output =~ self.should
+            break if @output =~ /#{self.should}/
           end
 
           if polling_frequency > 0 and tries > 1
@@ -126,8 +126,9 @@ Puppet::Type.newtype(:wait_for) do
       for that pattern to be seen, timing out after :max_retries
       retries."
 
-    munge do |value|
-      Regexp.new(value)
+    validate do |value|
+      raise ArgumentError,
+        "Regex must be a String, got value of class #{value.class}" unless value.is_a?(String)
     end
   end
 

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Type.type(:wait_for) do
     :seconds     => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
     :max_retries => [[42.5, 42.5], [42, 42], ['42', 42]],
     :polling_frequency => [[1.5, 1.5], [1, 1.0]],
-    :regex             => [[/foo/, /foo/], ['foo', /foo/]],
+    :regex             => [['foo', 'foo']],
   }
 
   test_data.each do |k,v|
@@ -75,6 +75,17 @@ describe Puppet::Type.type(:wait_for) do
       )
     }.to raise_error(
       Puppet::ResourceError, %r{Invalid environment setting 'foo'}
+    )
+  end
+
+  it 'errors out if regex is not a string' do
+    expect {
+      Puppet::Type.type(:wait_for).new(
+        :query  => 'echo foo bar',
+        :regex => /foo/,
+      )
+    }.to raise_error(
+      Puppet::ResourceError, %r{Regex must be a String}
     )
   end
 


### PR DESCRIPTION
Prior to this PR, the regex parameter was munged into a Regexp. This
caused pcore serialization of the Regexp in a report, when the regex was
really just a string used for comparison within a regex. This PR
changes the regex to be a string and uses the string as a regex when
testing for a match.

In the report, we would have something like the following. 

~~~
        "Wait_for[without implicit namevar]": {
...
            "events": [
                {
                    "audited": false,
                    "corrective_change": true,
                    "desired_value": {
                        "__pcore_type__": "Regexp",
                        "__pcore_value__": "foobar"
~~~

After this change, we no longer have the pcore serialization of the value. It is simply the string, which we were looking for.

~~~
        "Wait_for[without implicit namevar]": {
...
            "events": [
                {
                    "audited": false,
                    "corrective_change": true,
                    "desired_value": "foobar",
                    "historical_value": null,
~~~