### PR TITLE
Implement waiting for files/directories to be absent/present.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'pdk'
   gem 'pry'
   gem 'pry-rescue'
   gem 'pry-stack_explorer'

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 [![Build Status](https://img.shields.io/travis/heini/puppet-wait-for.svg)](https://travis-ci.org/heini/puppet-wait-for)
 
-A Puppet resource type that enables you to wait for certain conditions. You can use shell commands to query arbitrary things and either react on the exit code or match the output of the command against a regular expression.
+A Puppet resource type that enables you to either wait for certain amount of time or certain conditions, like
+- shell commands to query arbitrary things and either react on the exit code or match the output of the command against a regular expression, or
+- files or directories to (dis-)appear (new in 3.0)
 
 Warning: By using this module you are leaving the purist Puppet philosophy - this is not really a resource whose state can updated/kept in sync by Puppet. Also, you might be tempted to use this module to work around issues that should be fixed by other means.
 
-That said, there are situations where this might come in handy - for example, when you need to start/stop services in some asynchronous fashion. Puppet's basic assumption is, that when the code to update a resource has finished, then the resource is in the desired state, period. In the real world, this is not always the case, especially if you are doing a lot of things via exec resources and even more if the exec commandforks or kicks off a process which needs some time to come up.
+That said, there are situations where this might come in handy - for example, when you need to start/stop services in some asynchronous fashion. Puppet's basic assumption is, that when the code to update a resource has finished, then the resource is in the desired state, period. In the real world, this is not always the case, especially if you are doing a lot of things via exec resources and even more if the exec command forks or kicks off a process which needs some time to come up.
 
 ## Installation
 
@@ -20,6 +22,26 @@ Or add to your Puppetfile:
 
 ```text
 mod 'heini/wait_for'
+```
+
+## Migrating to version 3.x
+
+With the addition of waiting for files/directories, it doesn't make sense anymore for "query" to be the namevar, which means it must from now on be explicitely provided. For example, instead of writing
+
+```puppet
+wait_for { 'command':
+  exit_code => 0,
+  ...
+}
+```
+one should now write
+
+```puppet
+wait_for { 'command_returns_0':
+  query     => 'command',
+  exit_code => 0,
+  ...
+}
 ```
 
 ## Usage
@@ -84,6 +106,14 @@ wait_for { 'FOO is set':
 }
 ```
 
+Wait for a file/directory to (dis-)appear
+```puppet
+wait_for { 'some_new_file':
+  path  => '/tmp/foo',
+  state => file,   # or present, absent or directory
+}
+```
+
 ## Testing
 
 ### Testing
@@ -109,12 +139,12 @@ bundle exec rake spec
 To also run the acceptance tests:
 
 ```text
-export BEAKER_PUPPET_COLLECTION=puppet6
-export BEAKER_PUPPET_INSTALL_VERSION=6.4.2
+export BEAKER_PUPPET_COLLECTION=puppet7
+export BEAKER_PUPPET_INSTALL_VERSION=7.32.1
 bundle exec rspec spec/acceptance
 ```
 
-Tested using Puppet 6.4.2 and Ruby 2.4.1.
+Tested using Puppet 7.32.1, 8.8.1 and Ruby 3.1.4.
 
 ### Release
 
@@ -124,7 +154,7 @@ Ensure you have these lines in `~/.bash_profile`:
 
 ```text
 export BLACKSMITH_FORGE_URL=https://forgeapi.puppetlabs.com
-export BLACKSMITH_FORGE_USERNAME=heini
+export BLACKSMITH_FORGE_USERNAME=xxxxx
 export BLACKSMITH_FORGE_PASSWORD=xxxxxxxxx
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ wait_for { 'logstash':
 Wait for a Windows MySQL service to start:
 
 ```puppet
-wait_for { 'sc query MySQL5':
+wait_for { 'MySQL service running':
+  query => 'sc query MySQL5',
   regex => '.*STATE\s*:\s*4\s*RUNNING.*',
 }
 ```
@@ -57,7 +58,8 @@ wait_for { 'sc query MySQL5':
 Wait until a command returns an exit code of 5:
 
 ```puppet
-wait_for { 'scp big_file user@remote.com:/tmp':
+wait_for { 'Copy to remote host':
+  query             => 'scp big_file user@remote.com:/tmp',
   exit_code         => 5,   # Handle exit code 5, connection lost.
   polling_frequency => 0.3,
   max_retries       => 5,
@@ -75,18 +77,10 @@ wait_for { 'a_minute':
 Execute a command and inject some environment variables (just like 'exec' does).
 
 ```puppet
-wait_for { 'env':
+wait_for { 'FOO is set':
+  query       => 'env',
   environment => ['FOO=bar', 'BAR=baz'],
   regex       => 'FOO=.*',
-}
-```
-
-Use the query namevar:
-
-```puppet
-wait_for { 'without implicit namevar':
-  query => 'echo foobar',
-  regex => 'foobar',
 }
 ```
 

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -60,14 +60,30 @@ module Mixins
         tries.times do |try|
 
           # Only add debug messages for tries > 1 to reduce log spam.
-          #
           debug("Wait_for try #{try+1}/#{tries}") if tries > 1
-          @output = provider.run(self.resource[:query])
 
-          if self.class == Puppet::Type::Wait_for::Exit_code
-            status = self.should.include?(@output.exitstatus.to_i)
-          elsif self.class == Puppet::Type::Wait_for::Regex
-            status = @output =~ /#{self.should}/
+          # Handle command execution
+          if self.resource[:query]
+            @output = provider.run(self.resource[:query])
+
+            if self.class == Puppet::Type::Wait_for::Exit_code
+              status = self.should.include?(@output.exitstatus.to_i)
+            elsif self.class == Puppet::Type::Wait_for::Regex
+              status = @output =~ /#{self.should}/
+            end
+          elsif self.resource[:path]
+            if self.class == Puppet::Type::Wait_for::State
+              status = case self.should
+                       when :absent
+                         not File.exist?(self.resource[:path])
+                       when :directory
+                         File.directory?(self.resource[:path])
+                       when :file
+                         File.file?(self.resource[:path])
+                       when :present
+                         File.exist?(self.resource[:path])
+                       end
+            end
           end
 
           break if status
@@ -78,7 +94,7 @@ module Mixins
           end
         end
       rescue Timeout::Error
-        self.fail Puppet::Error, "Query exceeded timeout", $!
+        self.fail Puppet::Error, "Exceeded timeout", $!
       end
 
       unless status
@@ -86,6 +102,17 @@ module Mixins
           self.fail Puppet::Error, "Exit status #{@output.exitstatus.to_i} after max_retries"
         elsif self.class == Puppet::Type::Wait_for::Regex
           self.fail Puppet::Error, "Did not match regex after max_retries"
+        elsif self.class == Puppet::Type::Wait_for::State
+          case self.should
+          when :absent
+            self.fail Puppet::Error, "Filesystem element still present after max_retries"
+          when :directory
+            self.fail Puppet::Error, "Filesystem element isn't a directory or doesn't exist after max_retries"
+          when :file
+            self.fail Puppet::Error, "Filesystem element isn't a file or doesn't exist after max_retries"
+          when :present
+            self.fail Puppet::Error, "Filesystem element doesn't exist after max_retries"
+          end
         end
       end
     end
@@ -160,16 +187,45 @@ Puppet::Type.newtype(:wait_for) do
 
     validate do |value|
       raise ArgumentError,
-        "Regex must be a String, got value of class #{value.class}" unless value.is_a?(String)
+        "Regex must be of type String, got value of class #{value.class}" unless value.is_a?(String)
     end
+  end
+
+  newproperty(:state) do |property|
+    include Mixins
+
+    desc "If path is specified: Whether the filesystem element should be absent,
+      present, a file or a directory.
+
+      When present is specified, we only test for existance, regardles of type."
+
+    newvalues(:absent, :directory, :file, :present)
   end
 
   newproperty(:seconds) do
     include Mixins
-
     desc "Just wait this number of seconds no matter what."
+
     munge do |value|
-      value.to_i
+      value.to_f
+    end
+  end
+
+  newparam(:title, :namevar => true) do
+    desc "A short, unique description of what we're waiting for."
+
+    validate do |value|
+      raise ArgumentError,
+        "Title must be of type String, got value of class #{value.class}" unless value.is_a?(String)
+    end
+  end
+
+  newparam(:path) do
+    desc "A path on the filesystem which should (dis-)appear."
+
+    validate do |value|
+      raise ArgumentError,
+        "Path must be of type String, got value of class #{value.class}" unless value.is_a?(String)
     end
   end
 
@@ -177,11 +233,9 @@ Puppet::Type.newtype(:wait_for) do
     desc "The command to execute. The output of this command
       will be matched against the regex."
 
-    isnamevar
-
     validate do |command|
       raise ArgumentError,
-        "Command must be a String, got value of class #{command.class}" unless command.is_a?(String)
+        "Command must be of type String, got value of class #{command.class}" unless command.is_a?(String)
     end
   end
 
@@ -237,11 +291,11 @@ Puppet::Type.newtype(:wait_for) do
     munge do |value|
       if value.is_a?(String)
         unless value =~ /^[\d]+$/
-          raise ArgumentError, "Tries must be an integer"
+          raise ArgumentError, "Max_retries must be an integer"
         end
         value = Integer(value)
       end
-      raise ArgumentError, "Tries must be an integer >= 1" if value < 1
+      raise ArgumentError, "Max_retries must be an integer >= 1" if value < 1
       value
     end
 
@@ -255,7 +309,7 @@ Puppet::Type.newtype(:wait_for) do
 
     munge do |value|
       value = Float(value)
-      raise ArgumentError, "polling_frequency cannot be a negative number" if value < 0
+      raise ArgumentError, "Polling_frequency cannot be a negative number" if value < 0
       value
     end
 
@@ -306,17 +360,44 @@ Puppet::Type.newtype(:wait_for) do
       self.property(:exit_code).sync unless self.property(:exit_code).nil?
       self.property(:regex).sync     unless self.property(:regex).nil?
       self.property(:seconds).sync   unless self.property(:seconds).nil?
+      self.property(:state).sync   unless self.property(:state).nil?
+      self.property(:type).sync   unless self.property(:type).nil?
     end
   end
 
   validate do
-    unless self[:regex] or self[:exit_code] or self[:seconds]
-      fail "Exactly one of regex, seconds or exit_code is required."
+    # We either wait for some seconds, for a command (query) to return a
+    # specific (set of) exit code(s) or for a path on the filesystem to
+    # exist (or not)
+    if ((self[:seconds] and not self[:path].nil?) or
+        (self[:seconds] and not self[:query].nil?) or
+        (not self[:query].nil? and not self[:path].nil?))
+      fail "Attributes path, query and seconds are mutually exclusive."
     end
-    if (self[:regex] and not self[:exit_code].nil?) or
-       (self[:regex] and not self[:seconds].nil?) or
-       (not self[:exit_code].nil? and not self[:seconds].nil?)
-      fail "Attributes regex, seconds and exit_code are mutually exclusive."
+
+    # If a query command was provided, we either check for an exit code or a
+    # regex, but not both
+    if self[:query]
+      unless ((self[:regex] and self[:exit_code].nil?) or
+              (self[:exit_code] and self[:regex].nil?))
+        fail "Exactly one of regex or exit_code is required."
+      end
+      # We also don't want the state of a filesystem element in this case
+      if self[:state]
+        fail "Attribute state is not allowed with query."
+      end
+    end
+
+    # If a path was provided, we also expect a state and (if state is "present")
+    # a type to check for
+    if self[:path]
+      unless self[:state]
+        fail "Attribute state is required together with path."
+      end
+      # We also don't want regex or exit_code in this case
+      if self[:regex] or self[:exit_code]
+        fail "Attributes regex and exit_code are not allowed with path."
+      end
     end
   end
 end

--- a/lib/puppet/type/wait_for.rb
+++ b/lib/puppet/type/wait_for.rb
@@ -197,7 +197,7 @@ Puppet::Type.newtype(:wait_for) do
     desc "If path is specified: Whether the filesystem element should be absent,
       present, a file or a directory.
 
-      When present is specified, we only test for existance, regardles of type."
+      When present is specified, we only test for existence, regardles of type."
 
     newvalues(:absent, :directory, :file, :present)
   end
@@ -242,11 +242,7 @@ Puppet::Type.newtype(:wait_for) do
   newparam(:environment) do
     desc "An array of any additional environment variables you want to set for a
       command, such as `[ 'HOME=/root', 'MAIL=root@example.com']`.
-      Note that if you use this to set PATH, it will override the `path`
-      attribute. Multiple environment variables should be specified as an
-      array.
-
-      This was copied from the Exec type."
+      Multiple environment variables should be specified as an array."
 
     validate do |values|
       values = [values] unless values.is_a?(Array)
@@ -366,9 +362,8 @@ Puppet::Type.newtype(:wait_for) do
   end
 
   validate do
-    # We either wait for some seconds, for a command (query) to return a
-    # specific (set of) exit code(s) or for a path on the filesystem to
-    # exist (or not)
+    # We either wait for some seconds, execute a command (query) or check a
+    # path on the filesystem
     if ((self[:seconds] and not self[:path].nil?) or
         (self[:seconds] and not self[:query].nil?) or
         (not self[:query].nil? and not self[:path].nil?))
@@ -388,13 +383,12 @@ Puppet::Type.newtype(:wait_for) do
       end
     end
 
-    # If a path was provided, we also expect a state and (if state is "present")
-    # a type to check for
+    # If a path was provided, we also expect a state...
     if self[:path]
       unless self[:state]
         fail "Attribute state is required together with path."
       end
-      # We also don't want regex or exit_code in this case
+      # ...but no regex or exit_code
       if self[:regex] or self[:exit_code]
         fail "Attributes regex and exit_code are not allowed with path."
       end

--- a/metadata.json
+++ b/metadata.json
@@ -77,7 +77,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 9.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     }
   ],
   "dependencies": []

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "heini-wait_for",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "source": "https://github.com/heini/puppet-wait-for.git",
   "author": "Bastian Krol",
   "license": "Apache-2.0",

--- a/spec/acceptance/wait_for_spec.rb
+++ b/spec/acceptance/wait_for_spec.rb
@@ -12,15 +12,6 @@ describe 'wait_for' do
 
   it 'should successfully find foo' do
     pp = <<~EOF
-      wait_for { 'echo foo':
-        regex => 'foo',
-      }
-    EOF
-    expect(apply_manifest(pp).exit_code).to be_zero
-  end
-
-  it 'should successfully find foo with explicit query' do
-    pp = <<~EOF
       wait_for { 'foo':
         query => 'echo foo',
         regex => 'foo',
@@ -43,7 +34,8 @@ describe 'wait_for' do
 
   it 'should error out after max_retries if exit code is wrong' do
     pp = <<~EOF
-      wait_for { '/usr/bin/false':
+      wait_for { 'wrong exit code':
+        query             => '/usr/bin/false',
         exit_code         => 2,
         polling_frequency => 0.3,
         max_retries       => 5,
@@ -73,7 +65,8 @@ describe 'wait_for' do
 
   it 'should not error out after max_retries if exit code is wrong if refreshonly' do
     pp = <<~EOF
-      wait_for { '/usr/bin/false':
+      wait_for { 'wrong exit code':
+        query             => '/usr/bin/false',
         exit_code         => 2,
         polling_frequency => 0.3,
         max_retries       => 5,
@@ -98,7 +91,8 @@ describe 'wait_for' do
 
   it 'should inject variables' do
     pp = <<~EOF
-      wait_for { 'env':
+      wait_for { 'FOO is set':
+        query       => 'env',
         environment => ['FOO=bar', 'BAR=baz'],
         regex       => 'FOO=.*',
       }

--- a/spec/unit/puppet/provider/wait_for_spec.rb
+++ b/spec/unit/puppet/provider/wait_for_spec.rb
@@ -5,6 +5,7 @@ describe Puppet::Type.type(:wait_for).provider(:wait_for) do
   context '#run' do
     let(:resource) do
       Puppet::Type.type(:wait_for).new(
+        :title => 'run a command',
         :query => 'echo foo bar',
         :regex => 'baz',
       )

--- a/spec/unit/puppet/type/wait_for_spec.rb
+++ b/spec/unit/puppet/type/wait_for_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:wait_for) do
   let(:wait_for) do
-    Puppet::Type.type(:wait_for).new(:query => 'echo foo bar', :regex => 'foo')
+    Puppet::Type.type(:wait_for).new(:title => 'Testing with regex', :query => 'echo foo bar', :regex => 'foo')
+  end
+
+  let(:wait_for_seconds) do
+    Puppet::Type.type(:wait_for).new(:title => 'Wait for some seconds')
   end
 
   test_data = {
@@ -11,7 +15,6 @@ describe Puppet::Type.type(:wait_for) do
     # to the type's data type coercion.
     #
     :exit_code   => [[42.5, [42]], [[42], [42]], [42, [42]], ['42', [42]], [[1,'2','42'], [1,2,42]]],
-    :seconds     => [[42.5, 42], [[42], 42], [42, 42], ['42', 42]],
     :max_retries => [[42.5, 42.5], [42, 42], ['42', 42]],
     :polling_frequency => [[1.5, 1.5], [1, 1.0]],
     :regex             => [['foo', 'foo']],
@@ -31,34 +34,50 @@ describe Puppet::Type.type(:wait_for) do
     expect { wait_for }.not_to raise_error
   end
 
+  test_data_seconds = {
+    :seconds => [[42.5, 42.5], [[42], 42], [42, 42], ['42', 42]],
+  }
+
+  test_data_seconds.each do |k,v|
+    v.each do |val|
+      i, o = val
+      it "accepts #{k}=>#{i}" do
+        wait_for_seconds[k] = i
+        expect(wait_for_seconds[k]).to eq o
+      end
+    end
+  end
+
   bad_opts = [
-    {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42},
-    {:query  => 'echo foo bar', :regex  => 'foo', :exit_code => 42, :seconds => 42},
-    {:query  => 'echo foo bar', :regex  => 'foo', :seconds => 42},
-    {:query  => 'echo foo bar', :exit_code => 42, :seconds => 42},
+    {:title => 'Error case 1', :query => 'echo foo bar', :path => '/tmp/foo'},
+    {:title => 'Error case 2', :query => 'echo foo bar', :path => '/tmp/foo', :seconds => 42},
+    {:title => 'Error case 3', :path => '/tmp/foo', :seconds => 42},
+    {:title => 'Error case 4', :query => 'echo foo bar', :seconds => 42},
   ]
 
   bad_opts.each do |params|
     it "errors out with illegal opts #{params}" do
       expect { Puppet::Type.type(:wait_for).new(params) }.to raise_error(
-        Puppet::Error, %r{Attributes regex, seconds and exit_code are mutually exclusive}
+        Puppet::Error, %r{Attributes path, query and seconds are mutually exclusive.}
       )
     end
   end
 
-  it 'errors out unless one of regex, seconds or exit_code is specified' do
+  it 'errors out unless one of regex or exit_code is specified' do
     expect {
       Puppet::Type.type(:wait_for).new(
+        :title => 'Error case 5',
         :query  => 'echo foo bar',
       )
     }.to raise_error(
-      Puppet::ResourceError, %r{Exactly one of regex, seconds or exit_code is required}
+      Puppet::ResourceError, %r{Exactly one of regex or exit_code is required.}
     )
   end
 
   it 'errors out if environment is not an array' do
     expect {
       Puppet::Type.type(:wait_for).new(
+        :title => 'Error case 6',
         :query  => 'echo foo bar',
         :environment => 'foo',
       )
@@ -70,6 +89,7 @@ describe Puppet::Type.type(:wait_for) do
   it 'errors out if environment is not an array of strings like key=value' do
     expect {
       Puppet::Type.type(:wait_for).new(
+        :title => 'Error case 7',
         :query  => 'echo foo bar',
         :environment => ['foo'],
       )
@@ -81,11 +101,12 @@ describe Puppet::Type.type(:wait_for) do
   it 'errors out if regex is not a string' do
     expect {
       Puppet::Type.type(:wait_for).new(
+        :title => 'Error case 8',
         :query  => 'echo foo bar',
         :regex => /foo/,
       )
     }.to raise_error(
-      Puppet::ResourceError, %r{Regex must be a String}
+      Puppet::ResourceError, %r{Regex must be of type String}
     )
   end
 


### PR DESCRIPTION
Implements #20.

First shot at waiting for files. No tests, yet.

NOTE: Breaks backwards compatibility since `query` can't be the namevar anymore. Instead, a new attribute `title`has been introduced as namevar. This means that one of `query`, `seconds` or the new attribute `path` always needs to be provided.